### PR TITLE
Add edge metadata and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # llw-system-analysis
 Living Lab West - System Analysis
+
+## Usage
+
+Start a local web server in this directory (for example `python3 -m http.server`) and open `index.html` in your browser to view the system visualization. The page uses Cytoscape.js to render a graph described by `edges.csv`.
+
+`edges.csv` now contains the following columns:
+
+- `source` – the ID of the source node
+- `target` – the ID of the target node
+- `effect` – either `positive` or `negative`
+- `confidence` – either `sure` or `unsure`
+- `reference` – free‑text references or notes
+
+When the page loads, the CSV is fetched, parsed and displayed as a graph. Edges are styled according to their effect (green for positive, red for negative) and dashed if the confidence is unsure.

--- a/edges.csv
+++ b/edges.csv
@@ -1,0 +1,6 @@
+source,target,effect,confidence,reference
+A,B,positive,sure,Example reference 1
+B,C,negative,unsure,Example reference 2
+C,D,positive,sure,Example reference 3
+D,A,negative,sure,Example reference 4
+A,C,positive,unsure,Example reference 5

--- a/index.html
+++ b/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>System Visualization</title>
+    <style>
+        #cy {
+            width: 100%;
+            height: 600px;
+            border: 1px solid #ccc;
+        }
+        #info {
+            margin-top: 10px;
+            font-family: sans-serif;
+        }
+    </style>
+    <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+</head>
+<body>
+    <h1>System Visualization</h1>
+    <div id="cy"></div>
+    <div id="info"></div>
+    <script>
+        async function loadGraph() {
+            const response = await fetch('edges.csv');
+            const csvText = await response.text();
+            const parsed = Papa.parse(csvText.trim(), {header: true});
+
+            const nodes = new Set();
+            const edges = [];
+            parsed.data.forEach(row => {
+                const src = row.source.trim();
+                const tgt = row.target.trim();
+                const effect = (row.effect || '').trim();
+                const confidence = (row.confidence || '').trim();
+                const reference = (row.reference || '').trim();
+
+                nodes.add(src);
+                nodes.add(tgt);
+                edges.push({
+                    data: {
+                        id: src + '_' + tgt,
+                        source: src,
+                        target: tgt,
+                        effect: effect,
+                        confidence: confidence,
+                        reference: reference
+                    }
+                });
+            });
+
+            const elements = Array.from(nodes).map(n => ({ data: { id: n, label: n } })).concat(edges);
+
+            const cy = cytoscape({
+                container: document.getElementById('cy'),
+                elements: elements,
+                layout: { name: 'grid' },
+                style: [
+                    {
+                        selector: 'node',
+                        style: {
+                            'content': 'data(label)',
+                            'text-valign': 'center',
+                            'color': '#000',
+                            'background-color': '#61bffc'
+                        }
+                    },
+                    {
+                        selector: 'edge',
+                        style: {
+                            'curve-style': 'bezier',
+                            'target-arrow-shape': 'triangle',
+                            'width': 2,
+                            'line-color': '#ccc',
+                            'target-arrow-color': '#ccc'
+                        }
+                    },
+                    {
+                        selector: "edge[effect = 'positive']",
+                        style: {
+                            'line-color': '#2ecc71',
+                            'target-arrow-color': '#2ecc71'
+                        }
+                    },
+                    {
+                        selector: "edge[effect = 'negative']",
+                        style: {
+                            'line-color': '#e74c3c',
+                            'target-arrow-color': '#e74c3c'
+                        }
+                    },
+                    {
+                        selector: "edge[confidence = 'unsure']",
+                        style: {
+                            'line-style': 'dashed'
+                        }
+                    }
+                ]
+            });
+
+            cy.on('tap', 'edge', evt => {
+                const d = evt.target.data();
+                const info = `Effect: ${d.effect}\nConfidence: ${d.confidence}\nReference: ${d.reference}`;
+                document.getElementById('info').textContent = info;
+            });
+        }
+
+        loadGraph();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update `edges.csv` with columns for effect, confidence and reference
- style edges in `index.html` based on these new fields and show info on click
- mention running a local HTTP server in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68493fb9e7c48331b306bc28793a7009