### PR TITLE
Enhance visualization UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Start a local web server in this directory (for example `python3 -m http.server`
 - `reference` – free‑text references or notes
 
 When the page loads, the CSV is fetched, parsed and displayed as a graph. Edges are styled according to their effect (green for positive, red for negative) and dashed if the confidence is unsure.
+Clicking an edge shows its effect, confidence and reference. Clicking a node now displays its incoming and outgoing edge counts.

--- a/index.html
+++ b/index.html
@@ -5,14 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>System Visualization</title>
     <style>
+        body {
+            font-family: "Segoe UI", Tahoma, sans-serif;
+            background: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+            color: #333;
+        }
         #cy {
             width: 100%;
-            height: 600px;
+            height: 700px;
             border: 1px solid #ccc;
+            background: #fff;
+            border-radius: 4px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
         #info {
             margin-top: 10px;
-            font-family: sans-serif;
+            padding: 8px;
+            background: #fff;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            white-space: pre-line;
         }
     </style>
     <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
@@ -56,15 +71,17 @@
             const cy = cytoscape({
                 container: document.getElementById('cy'),
                 elements: elements,
-                layout: { name: 'grid' },
+                layout: { name: 'cose' },
                 style: [
                     {
                         selector: 'node',
                         style: {
                             'content': 'data(label)',
                             'text-valign': 'center',
-                            'color': '#000',
-                            'background-color': '#61bffc'
+                            'color': '#fff',
+                            'background-color': '#3498db',
+                            'text-outline-color': '#3498db',
+                            'text-outline-width': 2
                         }
                     },
                     {
@@ -73,22 +90,24 @@
                             'curve-style': 'bezier',
                             'target-arrow-shape': 'triangle',
                             'width': 2,
-                            'line-color': '#ccc',
-                            'target-arrow-color': '#ccc'
+                            'line-color': '#999',
+                            'target-arrow-color': '#999'
                         }
                     },
                     {
                         selector: "edge[effect = 'positive']",
                         style: {
-                            'line-color': '#2ecc71',
-                            'target-arrow-color': '#2ecc71'
+                            'line-color': '#27ae60',
+                            'target-arrow-color': '#27ae60',
+                            'width': 3
                         }
                     },
                     {
                         selector: "edge[effect = 'negative']",
                         style: {
-                            'line-color': '#e74c3c',
-                            'target-arrow-color': '#e74c3c'
+                            'line-color': '#c0392b',
+                            'target-arrow-color': '#c0392b',
+                            'width': 3
                         }
                     },
                     {
@@ -103,6 +122,12 @@
             cy.on('tap', 'edge', evt => {
                 const d = evt.target.data();
                 const info = `Effect: ${d.effect}\nConfidence: ${d.confidence}\nReference: ${d.reference}`;
+                document.getElementById('info').textContent = info;
+            });
+
+            cy.on('tap', 'node', evt => {
+                const n = evt.target;
+                const info = `Node: ${n.id()}\nIncoming edges: ${n.incomers('edge').length}\nOutgoing edges: ${n.outgoers('edge').length}`;
                 document.getElementById('info').textContent = info;
             });
         }


### PR DESCRIPTION
## Summary
- add subtle shadow around graph and info panels
- display node info on click
- document node interaction in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68494b27a0c88331bc7b8d67ef104c6e