### PR TITLE
Add interactive network viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>LLW System Analysis</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/cytoscape@3.23.0/dist/cytoscape.min.js"></script>
+    <script src="https://unpkg.com/cytoscape-popper@1.0.7/cytoscape-popper.js"></script>
+    <script src="https://unpkg.com/@popperjs/core@2/dist/umd/popper.min.js"></script>
+    <script src="https://unpkg.com/tippy.js@6/dist/tippy-bundle.umd.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css" />
+    <script src="https://unpkg.com/papaparse@5.3.2/papaparse.min.js"></script>
+    <style>
+        html, body { height: 100%; margin: 0; }
+        #cy { height: 100%; }
+    </style>
+</head>
+<body class="h-screen flex">
+    <div id="cy" class="flex-1"></div>
+    <div id="sidebar" class="w-1/3 max-w-sm p-4 border-l border-gray-300 overflow-y-auto hidden"></div>
+    <script>
+        async function loadData() {
+            const csvText = await fetch('llw_system_analysis.csv').then(r => r.text());
+            const parsed = Papa.parse(csvText, { header: true }).data;
+            const rawNodes = [];
+            const edges = [];
+            parsed.forEach(row => {
+                if(!row.id) return;
+                if(row.id.includes('-')) {
+                    edges.push(row);
+                } else {
+                    rawNodes.push(row);
+                }
+            });
+            // Determine nodes referenced by edges
+            const nodesWithEdges = new Set();
+            edges.forEach(e => {
+                if(e.source) nodesWithEdges.add(e.source);
+                if(e.target) nodesWithEdges.add(e.target);
+            });
+            // Determine parent nodes
+            const parents = new Set();
+            rawNodes.forEach(n => {
+                rawNodes.forEach(m => {
+                    if(m.id.startsWith(n.id + '.')) parents.add(n.id);
+                });
+            });
+            // Filter nodes
+            const nodes = rawNodes.filter(n => nodesWithEdges.has(n.id) || parents.has(n.id));
+            // Build cytoscape elements
+            const elements = [];
+            nodes.forEach(n => {
+                const color = n.trend === 'positive' ? '#4ade80' : (n.trend === 'negative' ? '#f87171' : '#d1d5db');
+                elements.push({
+                    group: 'nodes',
+                    data: {
+                        id: n.id,
+                        label: n.label,
+                        displayLabel: n.id + ' ' + n.label,
+                        description: n.description,
+                        trend: n.trend,
+                        reliability: n.reliability,
+                        references: n.references,
+                        reviewers: n.reviewers,
+                        organisation: n.organisation,
+                        mandate: n.mandate,
+                        comments: n.comments,
+                        color: color
+                    }
+                });
+            });
+            edges.forEach(e => {
+                if(!e.source || !e.target) return;
+                const color = e.trend === 'positive' ? '#4ade80' : (e.trend === 'negative' ? '#f87171' : '#d1d5db');
+                elements.push({
+                    group: 'edges',
+                    data: {
+                        id: e.id,
+                        source: e.source,
+                        target: e.target,
+                        label: e.label,
+                        displayLabel: e.id + ' ' + e.label,
+                        description: e.description,
+                        trend: e.trend,
+                        reliability: e.reliability,
+                        references: e.references,
+                        reviewers: e.reviewers,
+                        organisation: e.organisation,
+                        mandate: e.mandate,
+                        comments: e.comments,
+                        color: color
+                    }
+                });
+            });
+            renderGraph(elements);
+        }
+
+        function renderGraph(elements) {
+            const cy = cytoscape({
+                container: document.getElementById('cy'),
+                elements: elements,
+                style: [
+                    {
+                        selector: 'node',
+                        style: {
+                            'shape': 'roundrectangle',
+                            'background-color': 'data(color)',
+                            'label': 'data(displayLabel)',
+                            'text-wrap': 'wrap',
+                            'text-valign': 'center',
+                            'text-halign': 'center',
+                            'padding': '10px',
+                            'color': '#000'
+                        }
+                    },
+                    {
+                        selector: 'edge',
+                        style: {
+                            'width': 2,
+                            'line-color': 'data(color)',
+                            'target-arrow-color': 'data(color)',
+                            'target-arrow-shape': 'triangle',
+                            'curve-style': 'bezier',
+                            'label': 'data(displayLabel)',
+                            'text-background-color': '#fff',
+                            'text-background-opacity': 1,
+                            'text-background-padding': '2px'
+                        }
+                    }
+                ],
+                layout: { name: 'breadthfirst', directed: true, padding: 10 }
+            });
+
+            // Tooltips
+            cy.elements().forEach(el => {
+                const d = el.data();
+                const content = `<div><strong>${d.label}</strong><br>${d.description || ''}<br>Trend: ${d.trend || ''}<br>Reliability: ${d.reliability || ''}</div>`;
+                tippy(el.popperRef(), { content, trigger: 'mouseenter', placement: 'bottom', hideOnClick: false });
+            });
+
+            const sidebar = document.getElementById('sidebar');
+            function showInfo(d) {
+                sidebar.innerHTML = `
+                    <h2 class="text-xl font-bold mb-2">${d.label}</h2>
+                    <p><strong>Description:</strong> ${d.description || ''}</p>
+                    <p><strong>Trend:</strong> ${d.trend || ''}</p>
+                    <p><strong>Reliability:</strong> ${d.reliability || ''}</p>
+                    <p><strong>References:</strong> ${d.references || ''}</p>
+                    <p><strong>Reviewers:</strong> ${d.reviewers || ''}</p>
+                    <p><strong>Organisation:</strong> ${d.organisation || ''}</p>
+                    <p><strong>Mandate:</strong> ${d.mandate || ''}</p>
+                    <p><strong>Comments:</strong> ${d.comments || ''}</p>
+                `;
+                sidebar.classList.remove('hidden');
+            }
+
+            cy.on('tap', 'node', evt => showInfo(evt.target.data()));
+            cy.on('tap', 'edge', evt => showInfo(evt.target.data()));
+            cy.on('tap', evt => { if(evt.target === cy) sidebar.classList.add('hidden'); });
+        }
+
+        loadData();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create index.html
- parse `llw_system_analysis.csv` with PapaParse and filter nodes
- visualize nodes and edges with Cytoscape
- color by trend and show info in a sidebar
- add hover tooltips for quick details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab6905fb48331b4a6a62498d05f19